### PR TITLE
Add ability to specify a keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Keychain Access
-================================
 
 I got annoyed that:
 
@@ -7,14 +6,21 @@ I got annoyed that:
 * I had to write my password all the time when using my own scrips, when i have this amazing osx keychain.
 * The security(1) - Command line interface to the keychain is very hard to use in scripts.
 
-So, I wrote this bash script to allow for easy access to the osx keychain.
+So, I wrote this bash script to allow for easy access to the macOS keychain.
 
-## Example usage:
-First add the username and password to the osx keychain
+---
+
+# Example usage
+
+## Google Mail Atom Feed
+
+First add the username and password to the osx keychain:
 
     security add-generic-password -s google -a mogensen -w PaSSW0rd
 
-Then use the keychain script to get the username and password
+This adds an entry to the login keychain.
+
+Then use the keychain script to get the username and password:
 
 ```bash
 gmail () {
@@ -23,7 +29,27 @@ gmail () {
 
      curl -u $USER:$PASS --silent "https://mail.google.com/mail/feed/atom" |  \
   	     perl -ne 'print "\t" if /<name>/; print "$2\n" if /<(title|name)>(.*)<\/\1>/;'
-	}
+}
 ```
 
-Se the man page [security(1) Mac OS X Manual Page](http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man1/security.1.html)
+## Specifying a keychain
+Create a new keychain:
+
+    security create-keychain -P my-new-keychain
+
+Add a new entry to the keychain:
+
+    security add-generic-password -s secret_server -a root -w PaSSW0rd my-new-keychain
+
+Then use the keychain script to get the username and password:
+
+```bash
+secret_server_api_credentials () {
+    USER=`keychain -u -s secret_server -k my-new-keychain`
+    PASS=`keychain -p -s secret_server -k my-new-keychain`
+    echo $USER:$PASS
+}
+```
+---
+
+See the man page [security(1) Mac OS X Manual Page](http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man1/security.1.html) for more options.

--- a/keychain.sh
+++ b/keychain.sh
@@ -17,7 +17,7 @@ do
 			shift 2;;
 		-v) verbose=1;
 			shift 1;;
-		*)  echo "Option [$1] not one of  [p, u, s, v]";    # Error (!)
+		*)  echo "Option [$1] not one of  [p, u, s, v, k]";    # Error (!)
 			exit;;
 	esac
 done

--- a/keychain.sh
+++ b/keychain.sh
@@ -13,6 +13,8 @@ do
 			shift 1;;
 		-s) SERVICE=$2;
 			shift 2;;
+        -k) KEYCHAIN=$3;
+			shift 2;;
 		-v) verbose=1;
 			shift 1;;
 		*)  echo "Option [$1] not one of  [p, u, s, v]";    # Error (!)
@@ -20,7 +22,7 @@ do
 	esac
 done
 
-SEC=`security find-generic-password -s $SERVICE -g 2>&1`
+SEC=`security find-generic-password -s $SERVICE -g $KEYCHAIN 2>&1`
 
 function getAttribute() {
 	echo `echo "$SEC" | grep "$1" | cut -d \" -f 4`

--- a/keychain.sh
+++ b/keychain.sh
@@ -13,7 +13,7 @@ do
 			shift 1;;
 		-s) SERVICE=$2;
 			shift 2;;
-        -k) KEYCHAIN=$3;
+		-k) KEYCHAIN=$3;
 			shift 2;;
 		-v) verbose=1;
 			shift 1;;

--- a/keychain.sh
+++ b/keychain.sh
@@ -2,6 +2,7 @@
 
 GETPASS=0
 GETUSER=0
+KEYCHAIN=""
 
 while [ "$1" != "" ]
 do
@@ -13,7 +14,7 @@ do
 			shift 1;;
 		-s) SERVICE=$2;
 			shift 2;;
-		-k) KEYCHAIN=$3;
+		-k) KEYCHAIN=$2;
 			shift 2;;
 		-v) verbose=1;
 			shift 1;;


### PR DESCRIPTION
Hi and thanks for this script.

I've added the ability to specify a keychain file to use, using an additional `-k KEYCHAIN` option. It's optional so doesn't break existing usage.